### PR TITLE
Switch to hash router

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,7 +9,7 @@ import Chapter07 from "@/books/core/Chapter07";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import {
-  createBrowserRouter,
+  createHashRouter,
   createRoutesFromElements,
   Navigate,
   Route,
@@ -18,7 +18,7 @@ import {
 
 import "./index.css";
 
-const router = createBrowserRouter(
+const router = createHashRouter(
   createRoutesFromElements(
     <Route path="/" element={<App />}>
       <Route path="grimwild" element={<Navigate to="/grimwild/about" replace />} />


### PR DESCRIPTION
Switch to createHashRouter from createBrowserRouter to improve browser refresh and GitHub pages.

Note: There are other ways to solve the issue of hitting refresh and getting a 404 on GitHub pages, but this seemed most straightforward for now. If we need better SEO support in the future, consider [react-snap](https://www.npmjs.com/package/react-snap).