### PR TITLE
Change fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="bg-page text-base-color font-text tracking-wide">
+<html lang="en" class="bg-page text-base-color font-text">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/src/assets/theme.css
+++ b/src/assets/theme.css
@@ -1,5 +1,5 @@
 @theme {
-  --font-text: "Playfair Display", serif;
-  --font-text-sc: "Playfair Display SC", serif;
-  --font-heading: "Lora", serif;
+  --font-text: "Lora", serif;
+  --font-text-sc: "Spectral SC", serif;
+  --font-heading: "Playfair Display", serif;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400..700;1,400..700&family=Playfair+Display+SC:ital,wght@0,400;0,700;0,900;1,400;1,700;1,900&family=Playfair+Display:ital,wght@0,400..900;1,400..900&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400..700;1,400..700&family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Spectral+SC:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;1,200;1,300;1,400;1,500;1,600;1,700;1,800&display=swap");
 @import "tailwindcss";
 @import "./assets/theme.css";
 @import "./assets/utilities.css";


### PR DESCRIPTION
Swap around the fonts to (hopefully) make the overall site easier to read while maintaining a similar style and feel to the original book.

- Lora becomes the main font used for our body text.
- Playfair Display becomes the main font used in our headings.
- Spectral SC is introduced for use in text rendered with small caps.